### PR TITLE
feat: manually set launch server ip

### DIFF
--- a/src/components/ContainerList.tsx
+++ b/src/components/ContainerList.tsx
@@ -2,7 +2,6 @@
 import React, { useEffect, useState, useRef } from 'react';
 import ContainerCard, { ContainerOption } from './ContainerCard';
 import SetResetPanel from './SetResetPanel';
-import Cookies from 'js-cookie';
 
 const DEFAULT_API_BASE = 'http://localhost:8080';
 
@@ -11,13 +10,6 @@ const ContainerList: React.FC = () => {
   const [eventMsgs, setEventMsgs] = useState<Record<string, string | null>>({});
   const [apiBase, setApiBase] = useState(DEFAULT_API_BASE);
   const sseRef = useRef<EventSource | null>(null);
-
-  useEffect(() => {
-    const savedApiBase = Cookies.get('launch_server_url');
-    if (savedApiBase) {
-      setApiBase(savedApiBase);
-    }
-  }, []);
 
   const fetchOptions = async () => {
     try {
@@ -106,7 +98,6 @@ const ContainerList: React.FC = () => {
   };
 
   const handleReset = () => {
-    Cookies.remove('launch_server_url');
     setApiBase(DEFAULT_API_BASE);
   };
 

--- a/src/components/SetResetPanel.tsx
+++ b/src/components/SetResetPanel.tsx
@@ -2,16 +2,18 @@
 import React, { useState, useEffect } from 'react';
 import Cookies from 'js-cookie';
 
-interface WebRTCSignalingConfigProps {
+interface SetResetPanelProps {
   onUrlChange: (url: string) => void;
   onReset: () => void;
+  defaultUrl: string;
+  id: string;
 }
 
-const WebRTCSignalingConfig: React.FC<WebRTCSignalingConfigProps> = ({ onUrlChange, onReset }) => {
-  const [url, setUrl] = useState('ws://localhost:8443');
+const SetResetPanel: React.FC<SetResetPanelProps> = ({ onUrlChange, onReset, defaultUrl,  id }) => {
+  const [url, setUrl] = useState(defaultUrl);
 
   useEffect(() => {
-    const savedUrl = Cookies.get('signaling_server_url');
+    const savedUrl = Cookies.get(id);
     if (savedUrl) {
       setUrl(savedUrl);
       onUrlChange(savedUrl);
@@ -23,7 +25,7 @@ const WebRTCSignalingConfig: React.FC<WebRTCSignalingConfigProps> = ({ onUrlChan
   };
 
   const handleSave = () => {
-    Cookies.set('signaling_server_url', url);
+    Cookies.set(id, url);
     onUrlChange(url);
   };
 
@@ -101,4 +103,4 @@ const WebRTCSignalingConfig: React.FC<WebRTCSignalingConfigProps> = ({ onUrlChan
   );
 };
 
-export default WebRTCSignalingConfig;
+export default SetResetPanel;

--- a/src/components/SetResetPanel.tsx
+++ b/src/components/SetResetPanel.tsx
@@ -9,7 +9,7 @@ interface SetResetPanelProps {
   id: string;
 }
 
-const SetResetPanel: React.FC<SetResetPanelProps> = ({ onUrlChange, onReset, defaultUrl,  id }) => {
+const SetResetPanel: React.FC<SetResetPanelProps> = ({ onUrlChange, onReset, defaultUrl, id }) => {
   const [url, setUrl] = useState(defaultUrl);
 
   useEffect(() => {

--- a/src/components/WebRTCClientPage.tsx
+++ b/src/components/WebRTCClientPage.tsx
@@ -5,7 +5,7 @@ import React, { useEffect, useRef, useState } from "react";
 import { createRoot } from "react-dom/client";
 import ROSLIB from "roslib";
 import WebRTCCustomPresetForm from "./WebRTCCustomPresetForm";
-import WebRTCSignalingConfig from "./WebRTCSignalingConfig";
+import SetResetPanel from "./SetResetPanel";
 import WebRTCPresetsPanel from "./WebRTCPresetsPanel";
 import VideoCapture from "./VideoCapture";
 
@@ -205,7 +205,7 @@ const GstWebRTCPage: React.FC<WebRTCClientPageProps> = ({
         <WebRTCPresetsPanel onPresetSelect={newPreset} />
       </div>
       <div style={{ marginTop: "2rem", display: "flex", justifyContent: "center" }}>
-        <WebRTCSignalingConfig onUrlChange={setSignalingUrl} onReset={() => reset()}/>
+        <SetResetPanel onUrlChange={setSignalingUrl} onReset={() => reset()} defaultUrl='ws://localhost:8443' id='signaling_server_url'/>
       </div>
       <div
         style={{

--- a/start.sh
+++ b/start.sh
@@ -21,6 +21,5 @@ docker run --rm --name tiling-server-container -d \
 docker run --rm --name cprt-webserver \
   -p 3000:3000 \
   -e NEXT_PUBLIC_TILE_SERVER="$LOCAL_IP:$TILING_SERVER_PORT" \
-  -e NEXT_PUBLIC_LAUNCHSERVER="$LOCAL_IP:8080" \
   cprtsoftware/web-ui:latest
 


### PR DESCRIPTION
Fixes ROVER-641

This pull request introduces a new reusable panel component for setting and resetting server URLs, refactors existing logic to use this component, and improves server URL configuration and persistence for both the Docker launch server and WebRTC signaling server. The changes also clean up legacy environment variable usage. 

### Server URL configuration and persistence

* Added a new `SetResetPanel` component (renamed from `WebRTCSignalingConfig`) that allows users to set and reset server URLs, with persistence via cookies and support for configurable defaults and cookie keys. (`src/components/SetResetPanel.tsx`) [[1]](diffhunk://#diff-bb67710b458b20efa496c2d1af833c0cded916e7dea6cde7b262e7355ed91cfdL5-R16) [[2]](diffhunk://#diff-bb67710b458b20efa496c2d1af833c0cded916e7dea6cde7b262e7355ed91cfdL26-R28) [[3]](diffhunk://#diff-bb67710b458b20efa496c2d1af833c0cded916e7dea6cde7b262e7355ed91cfdL104-R106)
* Updated `ContainerList` to use the new `SetResetPanel` for configuring the Docker launch server URL, storing the value in a cookie (`launch_server_url`), and using it for API calls and SSE connections. (`src/components/ContainerList.tsx`) [[1]](diffhunk://#diff-3feaa0ef6684f7369d1dcb6d163476e31b0acbce76bb74ac856f9bdb259a8f0cR1-R24) [[2]](diffhunk://#diff-3feaa0ef6684f7369d1dcb6d163476e31b0acbce76bb74ac856f9bdb259a8f0cL36-R45) [[3]](diffhunk://#diff-3feaa0ef6684f7369d1dcb6d163476e31b0acbce76bb74ac856f9bdb259a8f0cL46-L62) [[4]](diffhunk://#diff-3feaa0ef6684f7369d1dcb6d163476e31b0acbce76bb74ac856f9bdb259a8f0cL77-R123)
* Refactored WebRTC client page to use `SetResetPanel` for the signaling server URL, replacing the old `WebRTCSignalingConfig` and ensuring the URL is persisted in the `signaling_server_url` cookie. (`src/components/WebRTCClientPage.tsx`) [[1]](diffhunk://#diff-a7e7a6ee344b825b448b6febb12ffc023ea05508fab43835f4922dfd43320445L8-R8) [[2]](diffhunk://#diff-a7e7a6ee344b825b448b6febb12ffc023ea05508fab43835f4922dfd43320445L208-R208)

### Cleanup and refactoring

* Removed the legacy environment variable `NEXT_PUBLIC_LAUNCHSERVER` from the Docker webserver startup script, as server URL configuration is now handled via the UI and cookies. (`start.sh`)
* Improved event handling and state updates in `ContainerList` for container lifecycle events, ensuring options are refreshed and messages are updated consistently. (`src/components/ContainerList.tsx`)