### PR TITLE
feat: dynamically space the launch panels

### DIFF
--- a/src/components/ContainerList.tsx
+++ b/src/components/ContainerList.tsx
@@ -112,15 +112,23 @@ const ContainerList: React.FC = () => {
           onReset={handleReset}
         />
       </div>
-      {options.map((opt) => (
-        <ContainerCard
-          key={opt.key}
-          option={opt}
-          onStart={startContainer}
-          onStop={stopContainer}
-          eventMsg={eventMsgs[opt.key] || null}
-        />
-      ))}
+      <div
+        style={{
+          display: 'grid',
+          gridTemplateColumns: 'repeat(auto-fit, minmax(clamp(300px, 100%, 700px), 1fr))',
+          gap: 16,
+          alignItems: 'start',
+        }}>
+        {options.map((opt) => (
+          <ContainerCard
+            key={opt.key}
+            option={opt}
+            onStart={startContainer}
+            onStop={stopContainer}
+            eventMsg={eventMsgs[opt.key] || null}
+          />
+        ))}
+      </div>
     </div>
   );
 };


### PR DESCRIPTION
We are going to be adding additional launch pannels. This some of them to be side by side when the screen is large enough and reduce scrolling. Small screens such as phones should behave the same.

<img width="1852" height="1053" alt="Screenshot from 2025-11-05 14-45-22" src="https://github.com/user-attachments/assets/287e520d-7454-4130-b79e-a02085712229" />
