### PR TITLE
feat: add rover update

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "next-runtime-env": "^3.3.0",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
+        "react-hot-toast": "^2.6.0",
         "react-icons": "^5.5.0",
         "react-leaflet": "^5.0.0",
         "react-mosaic-component": "^6.1.1",
@@ -3749,6 +3750,15 @@
       "integrity": "sha512-b/ZCF6amfAUb7dJM/MxRs7AetQEahYzJ8PtgfrmEdtw6uyGOr+ZSGtgjFm6mfsBkxJ4d2W7kg+Nlqzqvn3Bc0w==",
       "license": "MIT"
     },
+    "node_modules/goober": {
+      "version": "2.1.18",
+      "resolved": "https://registry.npmjs.org/goober/-/goober-2.1.18.tgz",
+      "integrity": "sha512-2vFqsaDVIT9Gz7N6kAL++pLpp41l3PfDuusHcjnGLfR6+huZkl6ziX+zgVC3ZxpqWhzH6pyDdGrCeDhMIvwaxw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "csstype": "^3.0.10"
+      }
+    },
     "node_modules/gopd": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
@@ -5565,6 +5575,23 @@
       "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-3.2.2.tgz",
       "integrity": "sha512-nsO+KSNgo1SbJqJEYRE9ERzo7YtYbou/OqjSQKxV7jcKox7+usiUVZOAC+XnDOABXggQTno0Y1CpVnuWEc1boQ==",
       "license": "MIT"
+    },
+    "node_modules/react-hot-toast": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/react-hot-toast/-/react-hot-toast-2.6.0.tgz",
+      "integrity": "sha512-bH+2EBMZ4sdyou/DPrfgIouFpcRLCJ+HoCA32UoAYHn6T3Ur5yfcDCeSr5mwldl6pFOsiocmrXMuoCJ1vV8bWg==",
+      "license": "MIT",
+      "dependencies": {
+        "csstype": "^3.1.3",
+        "goober": "^2.1.16"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "react": ">=16",
+        "react-dom": ">=16"
+      }
     },
     "node_modules/react-icons": {
       "version": "5.5.0",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "next-runtime-env": "^3.3.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
+    "react-hot-toast": "^2.6.0",
     "react-icons": "^5.5.0",
     "react-leaflet": "^5.0.0",
     "react-mosaic-component": "^6.1.1",

--- a/src/app/launch/page.tsx
+++ b/src/app/launch/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import Layout from "../../components/Layout";
+import { Toaster } from "react-hot-toast";
 import dynamic from 'next/dynamic';
 
 const ContainerListPage = dynamic(() => import("../../components/ContainerList"), { ssr: false });
@@ -9,6 +10,7 @@ export default function Launch() {
   return (
     <Layout>
       <ContainerListPage/>
+      <Toaster />
     </Layout>
   );
 }

--- a/src/components/SetResetPanel.tsx
+++ b/src/components/SetResetPanel.tsx
@@ -7,9 +7,11 @@ interface SetResetPanelProps {
   onReset: () => void;
   defaultUrl: string;
   id: string;
+  button1Name?: string;
+  button2Name?: string;
 }
 
-const SetResetPanel: React.FC<SetResetPanelProps> = ({ onUrlChange, onReset, defaultUrl, id }) => {
+const SetResetPanel: React.FC<SetResetPanelProps> = ({ onUrlChange, onReset, defaultUrl, id, button1Name="Set Server", button2Name="Reset" }) => {
   const [url, setUrl] = useState(defaultUrl);
 
   useEffect(() => {
@@ -77,7 +79,7 @@ const SetResetPanel: React.FC<SetResetPanelProps> = ({ onUrlChange, onReset, def
         onMouseDown={(e) => (e.currentTarget.style.transform = 'scale(0.97)')}
         onMouseUp={(e) => (e.currentTarget.style.transform = 'scale(1)')}
       >
-        Set Server
+        {button1Name}
       </button>
       <button
         onClick={onReset}
@@ -97,7 +99,7 @@ const SetResetPanel: React.FC<SetResetPanelProps> = ({ onUrlChange, onReset, def
         onMouseDown={(e) => (e.currentTarget.style.transform = 'scale(0.97)')}
         onMouseUp={(e) => (e.currentTarget.style.transform = 'scale(1)')}
       >
-        Reset
+        {button2Name}
       </button>
     </div>
   );


### PR DESCRIPTION
This pull request introduces a user-friendly way to update Docker images from the UI, adds toast notifications for feedback, and improves button labeling for clarity. The most important changes are grouped below.

**Feature Addition: Docker Image Update Workflow**

* Added a new "Update system" button to the `SetResetPanel` in `ContainerList.tsx` that triggers pulling the latest versions of three Docker images (`cprtsoftware/rover:amd64`, `cprtsoftware/web-ui:latest`, and `cprtsoftware/container-launcher:latest`) from the backend. The process provides confirmation and feedback to the user. [[1]](diffhunk://#diff-3feaa0ef6684f7369d1dcb6d163476e31b0acbce76bb74ac856f9bdb259a8f0cL100-R136) [[2]](diffhunk://#diff-3feaa0ef6684f7369d1dcb6d163476e31b0acbce76bb74ac856f9bdb259a8f0cL112-R146)

**User Feedback Improvements**

* Integrated `react-hot-toast` to display real-time notifications for each Docker image pull operation, including loading, success, and error states, as well as a final "All pulls finished" message. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R22) [[2]](diffhunk://#diff-5bdc8059771e94224a04964f23553a0c27a8e027ccaad9bad02c975b6b227aa6R4) [[3]](diffhunk://#diff-5bdc8059771e94224a04964f23553a0c27a8e027ccaad9bad02c975b6b227aa6R13) [[4]](diffhunk://#diff-3feaa0ef6684f7369d1dcb6d163476e31b0acbce76bb74ac856f9bdb259a8f0cL100-R136)

**UI/UX Enhancements**

* Updated `SetResetPanel` to support customizable button names via new props `button1Name` and `button2Name`, allowing for more descriptive labels such as "Update system" instead of the generic "Reset". [[1]](diffhunk://#diff-bb67710b458b20efa496c2d1af833c0cded916e7dea6cde7b262e7355ed91cfdR10-R14) [[2]](diffhunk://#diff-bb67710b458b20efa496c2d1af833c0cded916e7dea6cde7b262e7355ed91cfdL80-R82) [[3]](diffhunk://#diff-bb67710b458b20efa496c2d1af833c0cded916e7dea6cde7b262e7355ed91cfdL100-R102)