### PR TITLE
feat: fix useless padding

### DIFF
--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -50,7 +50,7 @@ const Layout: React.FC<LayoutProps> = ({ children }) => {
         }
         .mainContent {
           flex: 1;
-          padding: 1rem;
+          padding: 0;
           overflow-y: auto;
         }
       `}</style>


### PR DESCRIPTION
old padding was wasting space for no reason. Got rid of it in this commit. 
Old:
<img width="3840" height="2240" alt="image" src="https://github.com/user-attachments/assets/96bdef9a-c116-437d-b856-29240068e3fd" />

New:
<img width="3840" height="2242" alt="image" src="https://github.com/user-attachments/assets/f4475574-db22-4d03-bf73-f2a92cd35c50" />
