### PR TITLE
PDB power rail control

### DIFF
--- a/src/components/panels/MosaicDashboard.tsx
+++ b/src/components/panels/MosaicDashboard.tsx
@@ -21,6 +21,7 @@ import MotorStatusPanel from './MotorStatusPanel';
 import AntennaControlPanel from './AntennaControlPanel';
 import ScienceControlPanel from './ScienceControlPanel';
 import { CO2Graph, MethaneGraph } from './ScienceGraphPanels';
+import PDBRailsPanel from './PDBRails';
 
 type TileType =
   | 'mapView'
@@ -35,7 +36,8 @@ type TileType =
   | 'antennaControlPanel'
   | 'scienceControlPanel'
   | 'co2Graph'
-  | 'methaneGraph';
+  | 'methaneGraph'
+  | 'pdbRails';
 
 type TileId = `${TileType}:${number}`;
 
@@ -53,6 +55,7 @@ const TILE_DISPLAY_NAMES: Record<TileType, string> = {
   scienceControlPanel: 'Science Motor Control',
   co2Graph: 'CO2 Graph',
   methaneGraph: 'Methane Graph',
+  pdbRails: 'PDB Rails',
 };
 
 const ALL_TILE_TYPES: TileType[] = [
@@ -68,7 +71,8 @@ const ALL_TILE_TYPES: TileType[] = [
   'antennaControlPanel',
   'scienceControlPanel',
   'co2Graph',
-  'methaneGraph'
+  'methaneGraph',
+  'pdbRails'
 ];
 
 function tileTypeOf(id: TileId): TileType {
@@ -398,6 +402,13 @@ const MosaicDashboard: React.FC = () => {
             <MethaneGraph />
           </MosaicWindow>
         )
+      
+      case 'pdbRails':
+        return(
+          <MosaicWindow {...windowProps}>
+            <PDBRailsPanel />
+          </MosaicWindow>
+        );
 
       default:
         return <div>Unknown tile</div>;

--- a/src/components/panels/PDBRails.tsx
+++ b/src/components/panels/PDBRails.tsx
@@ -4,14 +4,6 @@ import React, { useEffect, useState } from "react";
 import ROSLIB from "roslib";
 import { useROS } from '@/ros/ROSContext';
 
-const dotStyle = (up: boolean): React.CSSProperties => ({
-  width: 12,
-  height: 12,
-  borderRadius: "50%",
-  display: "inline-block",
-  backgroundColor: up ? "#22c55e" : "#ef4444",
-});
-
 const LABELS = [
   "12V #1",
   "12V #2",
@@ -88,56 +80,115 @@ const PDBRailsPanel: React.FC = () => {
 
   const failBorder = (idx: number) => {
     if (pg[idx] === false && toggle[idx] === false) {
-      return "3px solid #ffc42b"
+      return "warn"
     }else {
-      return "none"
+      return ""
     }
   }
 
   return (
-    <div
-      style={{
-        background: "#1e1e1e",
-        color: "#f1f1f1",
-        padding: 0,
-        height: "100%",
-        overflowY: "auto",
-        display: "flex",
-        flexDirection: "column",
-      }}
-    >
+    <div className="pdb-panel">
       <div style={{ marginTop: 0 }}>
-        <table style={{ width: "100%", borderCollapse: "collapse" }}>
+        <table>
           <thead>
             <tr>
-              <th style={{ borderBottom: "1px solid #333" }}></th>
-              {LABELS.map((r, idx) => (
-                <th style={{ textAlign: "center", padding: "8px", borderBottom: "1px solid #333" }}>
-                  {r}
-                </th>
-              ))}
+              <th>Rail</th>
+              <th>PG</th>
+              <th>Toggle</th>
             </tr>
           </thead>
           <tbody>
-            <tr>
-              <td style={{ padding: "8px", textAlign: "center", fontWeight: "bold", borderBottom: "1px solid #222" }}>Power Good</td>
-              {pg.map((r, idx) => (
-                <td style={{ padding: "8px", textAlign: "center", borderBottom: "1px solid #222", borderTop: failBorder(idx), borderLeft: failBorder(idx), borderRight: failBorder(idx) }}>
-                  <span style={dotStyle(r)} />
+            {LABELS.map((r, idx) => (
+              <tr className={failBorder(idx)}>
+                <td>
+                  {r}
                 </td>
-              ))}
-            </tr>
-            <tr>
-              <td style={{ padding: "8px", textAlign: "center", fontWeight: "bold", borderBottom: "1px solid #222"  }}>Toggle</td>
-              {toggle.map((r, idx) => (
-                <td style={{ padding: "8px", textAlign: "center", borderBottom: "1px solid #222", borderLeft: failBorder(idx), borderRight: failBorder(idx)}}>
-                  <button style={{ padding: "8px", backgroundColor: r ? "#22c55e" : "#ef4444", borderRadius: "12px", borderStyle: "none" }} onClick={() => {toggleFn(idx)}}>{r ? "Enable" : "Disable"}</button>
+                <td>
+                  <span style={{ backgroundColor: pg[idx] ? "#22c55e" : "#ef4444" }} />
                 </td>
-              ))}
-            </tr>
+                <td>
+                  <button className={toggle[idx] ? "btn-on" : "btn-off"} onClick={() => {toggleFn(idx)}}>{toggle[idx] ? "On" : "Off"}</button>
+                </td>
+              </tr>
+            ))}
           </tbody>
         </table>
       </div>
+      <style jsx>{`
+        .pdb-panel {
+          background: #1e1e1e;
+          color: #f1f1f1;
+          padding: 0;
+          height: 100%;
+          overflow-y: auto;
+          display: flex;
+          flex-direction: column;
+          text-align: center;
+        }
+
+        table {
+          border-spacing: 0;
+          width: 100%;
+        }
+
+        th {
+          border-bottom: 1px solid #333;
+        }
+
+        td {
+          padding: 8px;
+          border-bottom: 1px solid #222;
+        }
+
+        .warn td {
+          padding: 5px 8px 5px 8px;
+          border: 3px solid #ffc42b;
+          border-style: solid none solid none;
+        }
+
+        .warn td:first-child {
+          padding: 5px 8px 5px 5px;
+          border: 3px solid #ffc42b;
+          border-style: solid none solid solid;
+        }
+        
+        .warn td:last-child {
+          padding: 5px 5px 5px 8px;
+          border: 3px solid #ffc42b;
+          border-style: solid solid solid none;
+        }
+        
+        span {
+          width: 12px;
+          height: 12px;
+          border-radius: 50%;
+          display: inline-block;
+        }
+
+        button {
+          min-width: 38px;
+          border-radius: 12px;
+          border-style: none;
+          padding: 8px;
+          cursor: pointer;
+        }
+
+        .btn-on {
+          background-color: #22c55e;
+        }
+
+        .btn-on:hover {
+          background-color: #1e7e34;
+        }
+
+        .btn-off {
+          background-color: #dc3545;
+        }
+
+        .btn-off:hover {
+          background-color: #A03232;
+        }
+      `}</style>
     </div>
   );
 };

--- a/src/components/panels/PDBRails.tsx
+++ b/src/components/panels/PDBRails.tsx
@@ -1,0 +1,143 @@
+'use client';
+
+import React, { useEffect, useState } from "react";
+import ROSLIB from "roslib";
+import { useROS } from "@/ros/ROSContext";
+
+const dotStyle = (up: boolean): React.CSSProperties => ({
+  width: 12,
+  height: 12,
+  borderRadius: "50%",
+  display: "inline-block",
+  backgroundColor: up ? "#22c55e" : "#ef4444",
+});
+
+const LABELS = [
+  "12V #1",
+  "12V #2",
+  "12V #3",
+  "12V #4",
+  "5V #1",
+  "5V #2",
+  "5V #3",
+];
+
+const PDBRailsPanel: React.FC = () => {
+  const { ros } = useROS();
+
+  const [pg, setPg] = useState([false, false, false, false, false, false, false]);
+  const [toggle, setToggle] = useState([false, false, false, false, false, false, false]); // Brittle -- assumes everything is enabled to begin with. This is bad but probably fine
+  
+  useEffect(() => {
+    if (!ros) return;
+
+    const pgTopic = new ROSLIB.Topic({
+      ros,
+      name: "/pdb_pg",
+      messageType: "std_msgs/msg/UInt8",
+    });
+
+    const handlePg = (msg: ROSLIB.Message) => {
+      const data = (msg as any).data as number;
+      setPg([
+        ((data & 0x01) ? true : false),
+        ((data & 0x02) ? true : false),
+        ((data & 0x04) ? true : false),
+        ((data & 0x08) ? true : false),
+        ((data & 0x10) ? true : false),
+        ((data & 0x20) ? true : false),
+        ((data & 0x40) ? true : false)
+      ]);
+    };
+
+    pgTopic.subscribe(handlePg);
+
+    return () => {
+      pgTopic.unsubscribe(handlePg);
+    };
+  }, [ros]);
+
+  const toggleFn = (idx) => {
+    const newToggle = toggle.map((el, i) => {
+      if (i === idx) {
+        return !el
+      }else {
+        return el
+      }
+    })
+    setToggle(newToggle)
+    
+    const toggleTopic = new ROSLIB.Topic({
+      ros,
+      name: "/pdb_toggle",
+      messageType: "std_msgs/msg/UInt8",
+    });
+
+    toggleTopic.publish(new ROSLIB.Message({ data: 
+      ((newToggle[0] ? 0x01 : 0x00) |
+       (newToggle[1] ? 0x02 : 0x00) |
+       (newToggle[2] ? 0x04 : 0x00) |
+       (newToggle[3] ? 0x08 : 0x00) |
+       (newToggle[4] ? 0x10 : 0x00) |
+       (newToggle[5] ? 0x20 : 0x00) |
+       (newToggle[6] ? 0x40 : 0x00))
+    }));
+  };
+
+  const failBorder = (idx) => {
+    if (pg[idx] === false && toggle[idx] === false) {
+      return "3px solid #ffc42b"
+    }else {
+      return "none"
+    }
+  }
+
+  return (
+    <div
+      style={{
+        background: "#1e1e1e",
+        color: "#f1f1f1",
+        padding: 0,
+        height: "100%",
+        overflowY: "auto",
+        display: "flex",
+        flexDirection: "column",
+      }}
+    >
+      <div style={{ marginTop: 0 }}>
+        <table style={{ width: "100%", borderCollapse: "collapse" }}>
+          <thead>
+            <tr>
+              <th style={{ borderBottom: "1px solid #333" }}></th>
+              {LABELS.map((r, idx) => (
+                <th style={{ textAlign: "center", padding: "8px", borderBottom: "1px solid #333" }}>
+                  {r}
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td style={{ padding: "8px", textAlign: "center", fontWeight: "bold", borderBottom: "1px solid #222" }}>Power Good</td>
+              {pg.map((r, idx) => (
+                <td style={{ padding: "8px", textAlign: "center", borderBottom: "1px solid #222", borderTop: failBorder(idx), borderLeft: failBorder(idx), borderRight: failBorder(idx) }}>
+                  <span style={dotStyle(r)} />
+                </td>
+              ))}
+            </tr>
+            <tr>
+              <td style={{ padding: "8px", textAlign: "center", fontWeight: "bold", borderBottom: "1px solid #222"  }}>Toggle</td>
+              {toggle.map((r, idx) => (
+                <td style={{ padding: "8px", textAlign: "center", borderBottom: "1px solid #222", borderBottom: failBorder(idx), borderLeft: failBorder(idx), borderRight: failBorder(idx)}}>
+                  <button style={{ padding: "8px", backgroundColor: r ? "#22c55e" : "#ef4444", borderRadius: "12px", borderStyle: "none" }} onClick={() => {toggleFn(idx)}}>{r ? "Enable" : "Disable"}</button>
+                </td>
+              ))}
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+};
+
+export default PDBRailsPanel;

--- a/src/components/panels/PDBRails.tsx
+++ b/src/components/panels/PDBRails.tsx
@@ -2,7 +2,7 @@
 
 import React, { useEffect, useState } from "react";
 import ROSLIB from "roslib";
-import { useROS } from "@/ros/ROSContext";
+import { useROS } from '@/ros/ROSContext';
 
 const dotStyle = (up: boolean): React.CSSProperties => ({
   width: 12,
@@ -33,7 +33,7 @@ const PDBRailsPanel: React.FC = () => {
 
     const pgTopic = new ROSLIB.Topic({
       ros,
-      name: "/pdb_pg",
+      name: "/pdb_rails/pdb_pg",
       messageType: "std_msgs/msg/UInt8",
     });
 
@@ -57,7 +57,7 @@ const PDBRailsPanel: React.FC = () => {
     };
   }, [ros]);
 
-  const toggleFn = (idx) => {
+  const toggleFn = (idx: number) => {
     const newToggle = toggle.map((el, i) => {
       if (i === idx) {
         return !el
@@ -66,10 +66,12 @@ const PDBRailsPanel: React.FC = () => {
       }
     })
     setToggle(newToggle)
+
+    if (!ros) return;
     
     const toggleTopic = new ROSLIB.Topic({
       ros,
-      name: "/pdb_toggle",
+      name: "/pdb_rails/pdb_toggle",
       messageType: "std_msgs/msg/UInt8",
     });
 
@@ -84,7 +86,7 @@ const PDBRailsPanel: React.FC = () => {
     }));
   };
 
-  const failBorder = (idx) => {
+  const failBorder = (idx: number) => {
     if (pg[idx] === false && toggle[idx] === false) {
       return "3px solid #ffc42b"
     }else {
@@ -128,7 +130,7 @@ const PDBRailsPanel: React.FC = () => {
             <tr>
               <td style={{ padding: "8px", textAlign: "center", fontWeight: "bold", borderBottom: "1px solid #222"  }}>Toggle</td>
               {toggle.map((r, idx) => (
-                <td style={{ padding: "8px", textAlign: "center", borderBottom: "1px solid #222", borderBottom: failBorder(idx), borderLeft: failBorder(idx), borderRight: failBorder(idx)}}>
+                <td style={{ padding: "8px", textAlign: "center", borderBottom: "1px solid #222", borderLeft: failBorder(idx), borderRight: failBorder(idx)}}>
                   <button style={{ padding: "8px", backgroundColor: r ? "#22c55e" : "#ef4444", borderRadius: "12px", borderStyle: "none" }} onClick={() => {toggleFn(idx)}}>{r ? "Enable" : "Disable"}</button>
                 </td>
               ))}


### PR DESCRIPTION
Adds a panel to interact with the PDB_Rails node. This reports power good from the e-fuses and can enable and disable individual rails. An orange border will appear around rails that are enabled but not reporting power good.