### PR TITLE
Tiling ip

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -2,7 +2,7 @@
 
 LOCAL_IP=""
 while [ -z "$LOCAL_IP" ]; do
-  LOCAL_IP=$(hostname -I | grep -oP '([0-9.]+(\.0)[0-9.]+)' || awk '{print $1}')
+  LOCAL_IP=$(ip addr show eno0 | grep -oP '(?<=inet )([0-9\.]+)' || hostname -I | awk '{print $1}')
   sleep 1
 done
 TILING_SERVER_PORT=80

--- a/start.sh
+++ b/start.sh
@@ -2,7 +2,7 @@
 
 LOCAL_IP=""
 while [ -z "$LOCAL_IP" ]; do
-  LOCAL_IP=$(hostname -I | awk '{print $1}')
+  LOCAL_IP=$(hostname -I | grep -oP '([0-9.]+(\.0)[0-9.]+)' || awk '{print $1}')
   sleep 1
 done
 TILING_SERVER_PORT=80

--- a/start.sh
+++ b/start.sh
@@ -2,7 +2,7 @@
 
 LOCAL_IP=""
 while [ -z "$LOCAL_IP" ]; do
-  LOCAL_IP=$(ip addr show eno0 | grep -oP '(?<=inet )([0-9\.]+)' || hostname -I | awk '{print $1}')
+  LOCAL_IP=$(ip addr show enP8p1s0 | grep -oP '(?<=inet )([0-9\.]+)' || hostname -I | awk '{print $1}')
   sleep 1
 done
 TILING_SERVER_PORT=80


### PR DESCRIPTION
Pulls the correct ip for the tiling server using the wired interface. Falls back on the first listed by `hostname -I` if wired isn't available. 