### PR TITLE
Fixed NaN crash for motor status.

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,12 @@ Access the dashboard at:
 [http://localhost:3000/dashboard](http://localhost:3000/dashboard)  
 (or use the host IP of the machine running the web app).
 
+Connect ros topics (if not running on rover). Run from rover repo, then click connect on Dashboard:
+
+```
+ros2 run rosbridge_server rosbridge_websocket
+```
+
 ## Docker
 
 You can run the dashboard using Docker for easier deployment.

--- a/src/components/panels/MotorStatusPanel.tsx
+++ b/src/components/panels/MotorStatusPanel.tsx
@@ -174,8 +174,8 @@ const MotorStatusPanel: React.FC = () => {
               return (
                 <tr key={key}>
                   <td>{label}</td>
-                  <td>{stat ? stat.velocity.toFixed(2) : '-'}</td>
-                  <td>{stat ? `${stat.output_current.toFixed(2)}A` : '-'}</td>
+                  <td>{stat && Number.isFinite(stat.velocity) ? stat.velocity.toFixed(2) : '-'}</td>
+                  <td>{stat && Number.isFinite(stat.output_current) ? `${stat.output_current.toFixed(2)}A` : '-'}</td>
                   <td><span className="status-led" style={{ backgroundColor: errorStr == "NONE" ? "#22c55e" : "#ef4444" }}/><span style={{ paddingLeft: "8px" }}>{errorStr}</span></td>
                   <td>
                     <button


### PR DESCRIPTION
Motor status crashes if NaN is published in the velocity and output_current. Added check to avoid this.

Also updated readme.

Also the NaN could possibly cause crashes in other float fields so someone should probably do something about that.